### PR TITLE
fix(snapshot image): fix snapshot image logging

### DIFF
--- a/src/reportDocument.ts
+++ b/src/reportDocument.ts
@@ -85,12 +85,13 @@ export class SnapshottingDocument implements PdfKitApi {
     return this.doCall("font", args);
   }
   image(...args) {
-    const callArgs =
+    const logArgs =
       args[0] instanceof Buffer
         ? [getChecksum(args[0].toString()), ...args.slice(1)]
         : [...args, getChecksum(fs.readFileSync(args[0]).toString())];
 
-    return this.doCall("image", callArgs);
+    this.logCall("image", logArgs);
+    return this.#pdfDoc.image.apply(this.#pdfDoc, args);
   }
   strokeColor(...args) {
     return this.doCall("strokeColor", args);


### PR DESCRIPTION
It was a mistake to pass in the string checkum as an image arg.  Pdfkit was trying to open that checksum as file, which couldn't be found.  Passing the original args to pdfkit and only logging the adjusted args for the snapshot calls.