### PR TITLE
fix: prevent infinite loops in splitColumn

### DIFF
--- a/src/paginate/splitColumn.test.ts
+++ b/src/paginate/splitColumn.test.ts
@@ -1,4 +1,9 @@
-import { splitColumn, continuedOn, continuedFrom } from "./splitColumn";
+import {
+  splitColumn,
+  continuedOn,
+  continuedFrom,
+  truncated,
+} from "./splitColumn";
 import { VerticalMeasure } from "measure/types";
 
 const newlineSample = `a short line
@@ -88,6 +93,59 @@ describe("splitColumn", () => {
         };
         expect(actual).toEqual(expectedObj);
       });
+    });
+  });
+
+  describe("when available space is smaller than a single part plus the continued marker", () => {
+    // measure: 1 unit per character
+    const measure = (txt: string): VerticalMeasure => ({
+      maxHeight: txt.length,
+      minHeight: txt.length,
+    });
+
+    it("should truncate instead of infinite looping when no single part fits", () => {
+      const input = "word1 word2 word3";
+      // availableSpace smaller than even the shortest possible left side
+      // ("word1" + continuedOn), so no split strategy can make progress.
+      const available = 3;
+
+      const result = splitColumn(input, measure, available);
+
+      // continuation must be strictly shorter than the input, otherwise
+      // pagination would never terminate
+      expect(result[1].length).toBeLessThan(input.length);
+      // nothing left to continue onto the next page
+      expect(result[1]).toBe("");
+      // the rendered cell fits the available space
+      expect(measure(result[0]).maxHeight).toBeLessThanOrEqual(available);
+    });
+
+    it("falls back to periods when even the truncated marker does not fit", () => {
+      const input = "word1 word2 word3";
+      const available = 2;
+
+      const result = splitColumn(input, measure, available);
+
+      expect(result[1]).toBe("");
+      expect(result[0]).toBe("..");
+      expect(measure(result[0]).maxHeight).toBeLessThanOrEqual(available);
+    });
+
+    it("appends the truncated marker with whatever content fits", () => {
+      const input = Array(20).fill("1234567890").join("");
+      // smaller than continuedOn (25) so no character split can make
+      // progress, but large enough to fit truncated (12) plus some content
+      const available = 20;
+
+      const result = splitColumn(input, measure, available);
+
+      expect(result[1]).toBe("");
+      expect(result[0].endsWith(truncated)).toBe(true);
+      expect(measure(result[0]).maxHeight).toBeLessThanOrEqual(available);
+      // it kept as much as could fit
+      expect(result[0]).toBe(
+        input.substring(0, available - truncated.length) + truncated
+      );
     });
   });
 

--- a/src/paginate/splitColumn.ts
+++ b/src/paginate/splitColumn.ts
@@ -2,6 +2,7 @@ import { VerticalMeasure } from "measure/types";
 
 export const continuedOn = " (continued on next page)";
 export const continuedFrom = "(continued from prev page) ";
+export const truncated = " (truncated)";
 
 /**
  * Use this function for the 'splitFn' {@link ColumnSetting} prop for a
@@ -30,24 +31,72 @@ export function splitColumn(
   measure: (text: string) => VerticalMeasure,
   availableSpace: number
 ): [string, string] {
-  let result = trySplitNewlines(value, measure, availableSpace);
+  let result =
+    trySplitNewlines(value, measure, availableSpace) ??
+    trySplitSpaces(value, measure, availableSpace) ??
+    trySplitCharacters(value, measure, availableSpace);
 
-  if (!result) {
-    result = trySplitSpaces(value, measure, availableSpace);
-  }
-
-  if (!result) {
-    let splitPosition = value.length;
-    do {
-      result = [
-        value.substring(0, splitPosition) + continuedOn,
-        continuedFrom + value.substring(splitPosition),
-      ];
-      splitPosition--;
-    } while (measure(result[0]).maxHeight > availableSpace);
+  // A split only counts if the continued-onto content is strictly shorter
+  // than the input; otherwise pagination would never make progress and loop
+  // forever. Compare undecorated content: result[1] carries a continuedFrom
+  // prefix that would otherwise inflate the length past the original.
+  const carriedForward = result?.[1].startsWith(continuedFrom)
+    ? result[1].substring(continuedFrom.length)
+    : result?.[1];
+  if (!result || carriedForward.length >= value.length) {
+    result = truncate(value, measure, availableSpace);
   }
 
   return result;
+}
+
+/**
+ * Last-resort hard break at a character boundary. Returns null when not even
+ * a single character of content plus the marker fits in availableSpace.
+ */
+function trySplitCharacters(
+  value: string,
+  measure: (text: string) => VerticalMeasure,
+  availableSpace: number
+): [string, string] | null {
+  for (
+    let splitPosition = value.length - 1;
+    splitPosition >= 1;
+    splitPosition--
+  ) {
+    const result: [string, string] = [
+      value.substring(0, splitPosition) + continuedOn,
+      continuedFrom + value.substring(splitPosition),
+    ];
+    if (measure(result[0]).maxHeight <= availableSpace) {
+      return result;
+    }
+  }
+  return null;
+}
+
+/**
+ * When the value cannot be split to fit at all, drop content. Append
+ * '(truncated)' to as much of the value as fits; if even the marker alone
+ * does not fit, fall back to as many periods as fit.
+ */
+function truncate(
+  value: string,
+  measure: (text: string) => VerticalMeasure,
+  availableSpace: number
+): [string, string] {
+  for (let keep = value.length; keep >= 0; keep--) {
+    const candidate = value.substring(0, keep) + truncated;
+    if (measure(candidate).maxHeight <= availableSpace) {
+      return [candidate, ""];
+    }
+  }
+
+  let dots = "";
+  while (measure(dots + ".").maxHeight <= availableSpace) {
+    dots += ".";
+  }
+  return [dots, ""];
 }
 
 function trySplitNewlines(
@@ -83,9 +132,15 @@ function trySplitDelimiter(
   const restParts = [parts.pop()];
 
   while (
+    parts.length > 1 &&
     measure(parts.join(delimiter) + continuedOn).maxHeight > availableSpace
   ) {
     restParts.unshift(parts.pop());
+  }
+
+  // The first part alone still does not fit; let another strategy handle it.
+  if (measure(parts.join(delimiter) + continuedOn).maxHeight > availableSpace) {
+    return null;
   }
 
   return [


### PR DESCRIPTION
trySplitDelimiter could pop past the start of its parts array, and the character-split fallback decremented its split position without a lower bound, both spinning forever when availableSpace was too small to fit even one unit of content plus the continuation marker.

Bound both loops and enforce a termination invariant: a split only counts if the content carried forward is strictly shorter than the input. When no strategy can satisfy that, truncate instead - appending " (truncated)" to whatever fits, or falling back to periods.