### PR TITLE
ci: upgrade semantic-release to v25 for npm OIDC trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,12 +45,12 @@ jobs:
     resource_class: large
     steps:
       - attach_workspace:
-          at: /workspace
+          at: /home/circleci/workspace
       - run:
           command: |
             npm run lint
             npm run prettier
-          working_directory: /workspace/reportscript
+          working_directory: /home/circleci/workspace/reportscript
       - notify-fail
   reportscript-tests:
     docker:
@@ -58,10 +58,10 @@ jobs:
     resource_class: small
     steps:
       - attach_workspace:
-          at: /workspace
+          at: /home/circleci/workspace
       - run:
           command: npm test
-          working_directory: /workspace/reportscript
+          working_directory: /home/circleci/workspace/reportscript
       - notify-fail
   reportscript-node-install:
     docker:
@@ -110,12 +110,12 @@ jobs:
     resource_class: small
     steps:
       - attach_workspace:
-          at: /workspace
+          at: /home/circleci/workspace
       - run:
           command: npm run build
-          working_directory: /workspace/reportscript
+          working_directory: /home/circleci/workspace/reportscript
       - persist_to_workspace:
-          root: /workspace
+          root: /home/circleci/workspace
           paths:
             - reportscript/dist
       - notify-fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ commands:
 jobs:
   reportscript-format-check:
     docker:
-      - image: node:20
+      - image: cimg/node:24.15
     resource_class: large
     steps:
       - attach_workspace:
@@ -54,7 +54,7 @@ jobs:
       - notify-fail
   reportscript-tests:
     docker:
-      - image: node:20
+      - image: cimg/node:24.15
     resource_class: small
     steps:
       - attach_workspace:
@@ -65,7 +65,9 @@ jobs:
       - notify-fail
   reportscript-node-install:
     docker:
-      - image: cimg/python:3.12.1-node
+      # python is required for node-gyp to build the native `canvas` dependency;
+      # the -node variant of this tag bundles Node 24 (current LTS)
+      - image: cimg/python:3.13-node
     resource_class: small
     steps:
       - checkout
@@ -93,7 +95,7 @@ jobs:
       - notify-success
   release:
     docker:
-      - image: node:20
+      - image: cimg/node:24.15
     resource_class: small
     steps:
       - attach_workspace:
@@ -104,7 +106,7 @@ jobs:
       - notify-fail
   build:
     docker:
-      - image: node:20
+      - image: cimg/node:24.15
     resource_class: small
     steps:
       - attach_workspace:

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "husky": "^8.0.3",
     "jest": "^27.0.6",
     "prettier": "2.8.7",
-    "semantic-release": "^22.0.7",
+    "semantic-release": "^25.0.3",
     "semantic-release-cli": "^5.4.4",
     "sinon": "^12.0.1",
     "ts-jest": "^27.0.4",


### PR DESCRIPTION
semantic-release@25 bundles @semantic-release/npm@13, which supports npm's OIDC trusted publishing. It requires Node ^22.14.0 || >=24.10.0 and npm >= 11.5.1, so all CircleCI jobs move to Node 24 (current LTS): the npm-install job needs python for node-gyp to build the native canvas dependency, so it uses cimg/python:3.13-node (bundles Node 24); the rest use cimg/node:24.15.