### PR TITLE
fix: explicitly mint NPM_ID_TOKEN for CircleCI OIDC publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@4.4.2
+  circleci-cli: circleci/circleci-cli@0.1.10
 commands:
   notify-fail:
     description: Notify failure via slack
@@ -109,20 +110,28 @@ jobs:
           # publish. semantic-release is run via npx per its install recommendation.
           command: npx semantic-release@25
           working_directory: /home/circleci/workspace/reportscript
+      # circleci CLI is not bundled in cimg/node; needed to mint a
+      # custom-audience OIDC token for npm trusted publishing (below)
+      - circleci-cli/install
       - run:
           name: npm publish via CircleCI OIDC trusted publishing
           # @semantic-release/npm only implements OIDC trusted publishing for
-          # GitHub Actions and GitLab, not CircleCI. The npm CLI (>= 11.5.1,
-          # bundled in cimg/node:24.15) does support CircleCI OIDC natively, so
-          # the actual publish runs here. semantic-release only bumps the version
-          # in package.json when there is a release to make; if it is still the
-          # placeholder, there is nothing to publish.
+          # GitHub Actions and GitLab, not CircleCI, so the actual publish runs
+          # here. Unlike those providers, npm does NOT auto-detect CircleCI OIDC:
+          # we must mint a token with the npm audience and pass it as
+          # NPM_ID_TOKEN, which `npm publish` then exchanges for a short-lived
+          # publish token. The pre-injected CIRCLE_OIDC_TOKEN_V2 cannot be used
+          # because its aud claim is the org UUID, not npm:registry.npmjs.org;
+          # only `circleci run oidc get` can mint a custom-audience token.
+          # semantic-release only bumps the version in package.json when there
+          # is a release to make; if it is still the placeholder, skip publish.
           command: |
             VERSION=$(node -p "require('./package.json').version")
             if [ "$VERSION" = "0.0.0-development" ]; then
               echo "No release was made by semantic-release; skipping npm publish."
               exit 0
             fi
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
             echo "Publishing reportscript@$VERSION via OIDC trusted publishing"
             npm publish
           working_directory: /home/circleci/workspace/reportscript

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 orbs:
   slack: circleci/slack@4.4.2
-  circleci-cli: circleci/circleci-cli@0.1.10
 commands:
   notify-fail:
     description: Notify failure via slack
@@ -110,9 +109,6 @@ jobs:
           # publish. semantic-release is run via npx per its install recommendation.
           command: npx semantic-release@25
           working_directory: /home/circleci/workspace/reportscript
-      # circleci CLI is not bundled in cimg/node; needed to mint a
-      # custom-audience OIDC token for npm trusted publishing (below)
-      - circleci-cli/install
       - run:
           name: npm publish via CircleCI OIDC trusted publishing
           # @semantic-release/npm only implements OIDC trusted publishing for
@@ -123,6 +119,15 @@ jobs:
           # publish token. The pre-injected CIRCLE_OIDC_TOKEN_V2 cannot be used
           # because its aud claim is the org UUID, not npm:registry.npmjs.org;
           # only `circleci run oidc get` can mint a custom-audience token.
+          #
+          # The circleci CLI is not bundled in cimg/node and must be installed.
+          # The circleci/circleci-cli orb is NOT used: every published version
+          # (<= 0.1.9) has a broken install command that silently no-ops when
+          # the CLI is not already present - see
+          # https://github.com/CircleCI-Public/circleci-cli-orb/issues/22 - and
+          # the fix on master was never published. This curl is exactly what the
+          # fixed orb runs internally.
+          #
           # semantic-release only bumps the version in package.json when there
           # is a release to make; if it is still the placeholder, skip publish.
           command: |
@@ -131,6 +136,7 @@ jobs:
               echo "No release was made by semantic-release; skipping npm publish."
               exit 0
             fi
+            curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | sudo bash
             export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
             echo "Publishing reportscript@$VERSION via OIDC trusted publishing"
             npm publish


### PR DESCRIPTION
npm does not auto-detect CircleCI OIDC the way it does for GitHub Actions and GitLab, so `npm publish` failed with ENEEDAUTH. CircleCI requires explicit token retrieval: mint an OIDC token with the npm:registry.npmjs.org audience and export it as NPM_ID_TOKEN, which the npm CLI then exchanges for a short-lived publish token.

The pre-injected CIRCLE_OIDC_TOKEN_V2 cannot be used - its aud claim is the org UUID, not the npm audience - so the token is minted via `circleci run oidc get --claims`. The circleci CLI is not bundled in cimg/node, so it is installed via the circleci/circleci-cli orb.